### PR TITLE
Ensure timeout error is set on results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 tcp-probe
 =========
 
-TCP probe utility for node.js. This tool allows you to test if a chosen address accepts connections at a desired port and measure latency, as well as validate responses and capture data. It's ideal for service availability testing and more advanced probing tasks. Derived from the `tcp-ping` library https://github.com/apaszke/tcp-ping
+TCP probe utility for node.js. This tool allows you to test if a chosen address accepts connections at a desired port and measure latency, as well as validate responses and capture data. It's ideal for service availability testing and more advanced probing tasks. Forked from [tcp-ping](https://github.com/apaszke/tcp-ping).
 
 ### Install
 
@@ -72,4 +72,4 @@ tcpp.probe({
 
 ```
 
-The `tcp-probe` library is based on the original `tcp-ping` library by Adam Paszke, with added request and response validation capabilities.
+The `tcp-probe` library is forked from the original [tcp-ping](https://github.com/apaszke/tcp-ping) library by Adam Paszke, with added request and response validation capabilities.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcp-probe",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A TCP ping tool to probe services and validate responses.",
   "main": "probe.js",
   "scripts": {

--- a/probe.js
+++ b/probe.js
@@ -203,7 +203,7 @@ function probe(options, callback) {
                 if (didPushResults) {
                     return;
                 }
-                let timeoutErr = s.connecting ? Error('Request timeout') : Error('Response timeout')
+                let timeoutErr = s.connecting ? Error('Request timeout') : Error('Response timeout');
                 lastErr = lastErr ?? timeoutErr;
                 probeResultCheck({ err: timeoutErr });
             }, options.timeout);

--- a/probe.js
+++ b/probe.js
@@ -203,8 +203,9 @@ function probe(options, callback) {
                 if (didPushResults) {
                     return;
                 }
-                lastErr = lastErr ?? Error('Response timeout');
-                probeResultCheck({ err: Error('Response timeout') });
+                let timeoutErr = s.connecting ? Error('Request timeout') : Error('Response timeout')
+                lastErr = lastErr ?? timeoutErr;
+                probeResultCheck({ err: timeoutErr });
             }, options.timeout);
 
             s.connect(options.port, options.address, function onConnect() {
@@ -290,11 +291,7 @@ function probe(options, callback) {
 
             // guaranteed to be called
             s.on('close', function onClose() {
-                probeResultCheck({});
-            });
-
-            s.setTimeout(options.timeout, function() {
-                probeResultCheck({});
+                probeResultCheck();
             });
 
             return;


### PR DESCRIPTION
Remove redundant timeout logic for isProbe branch to ensure timeout returns error
Use "Request Timeout" for timeout while connecting and "Response Timeout" for timeout after connection.